### PR TITLE
remove truste; it makes impossible to enter economist.com

### DIFF
--- a/filterlist.txt
+++ b/filterlist.txt
@@ -788,7 +788,6 @@ www.wykop.pl##DIV[class="annotation type-alert type-permanent lspace m-reset-pos
 ||app.cookieassistant.com/widget$script
 ||assets.cookieconsent.silktide.com^
 ||codehousegroup.com/js/libs/cookie-check.js
-||consent.truste.com
 ||cookie-script.com/s$script
 ||cookie-script.com^$third-party
 ||cookie.gazeta.pl/noScriptCookie.servlet


### PR DESCRIPTION
The filter `||consent.truste.com` enabled makes it impossible to see any content on `http://www.economist.com` if you don't have a proper cookie. When you enter economist without a cookie, you are showed only a popup to accept the cookie policy and no real content. With the filter in effect, you see just navigation links.