### PR TITLE
Fix broken blocking for vobadirekt.de

### DIFF
--- a/filterlist.txt
+++ b/filterlist.txt
@@ -1214,6 +1214,8 @@ www.quechoisir.org###bannerCnil
 www.sentres.com##.cookies-eu
 www.tf1.fr##.banner_cookies
 www.theguardian.com##.site-message--cookies.site-message--banner.js-site-message.site-message
+www.vobadirekt.de##.lightbox--cookie-consent
+www.vobadirekt.de##:xpath(//*[contains(@class, "darken-layer") and /*//*[contains(@class, "lightbox--cookie-consent")]])
 www.wykop.pl##DIV[class="annotation type-alert type-permanent lspace m-reset-position closableContainer"]
 zenska.si#@##cookie-bar
 zonaforo.meristation.com##.inner


### PR DESCRIPTION
Using the block list makes the website inaccessible. The filters leave behind
an empty modal and the drop shadow that covers the page.

According to the [uBlock Origin wiki](https://github.com/DandelionSprout/adfilt/blob/master/Wiki/SyntaxMeaningsThatAreActuallyHumanReadable.md#nano-adblocker-and-ublock-origin-only) the `:xpath` selector only works in Nano Blocker and uBlock Origin, but I couldn't find a better way to write this query. The only alternative I see would be to always block `.darken-layer`, regardless of which modal is shown.